### PR TITLE
handle that unicode-range can be passed as a single string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,16 @@
 class UnicodeRange {
   static REGEXP = /^u\+(?:([0-9a-f]?[0-9a-f?]{1,5})|([0-9a-f]{1,6})-([0-9a-f]{1,6}))?$/i;
 
-  static parse(arr: string[]): number[] {
-    const result = new Set<number>();
+  static splitRanges(ranges: string | string[]): string[] {
+    if (typeof ranges === 'string') {
+      return ranges.replace(/\s*/g, '').split(',');
+    }
+    return ranges;
+  }
 
+  static parse(ranges: string[] | string): number[] {
+    const result = new Set<number>();
+    const arr = UnicodeRange.splitRanges(ranges);
     for (const range of arr) {
       if (!UnicodeRange.REGEXP.test(range)) {
         throw new TypeError(`"${range}" is invalid unicode-range.`);


### PR DESCRIPTION
Given that the `unicode-range` CSS property is a single string, it could be nice if it accepted a string value and handled the splitting up into multiple ranges internally. Completely understand if you consider it to be out of scope for this library though, as it is super easy to do prior to calling `UnicodeRange.parse()`